### PR TITLE
Added embedded hints to challenges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Backend/bin/
 Backend/.classpath
 Backend/.project
 Backend/.settings/org.eclipse.buildship.core.prefs
+Backend/Backend.iml
+Backend/Backend.ipr
+Backend/Backend.iws
 
 # exclude everything
 Backend/src/main/resources/static/*

--- a/Backend/src/main/java/ar/edu/unlp/dsa/controller/ChallengeRestController.java
+++ b/Backend/src/main/java/ar/edu/unlp/dsa/controller/ChallengeRestController.java
@@ -76,7 +76,44 @@ public class ChallengeRestController {
 			throw new ChallengeNotFoundException(challengeId);
 		}
 		input.setId(challengeId);
+		Long deletedHint1Id = null;
+        if (challenge.getHint1() == null) {
+            if (input.getHint1() != null) {
+                Hint savedHint = this.getHintRepository().save(input.getHint1());
+                input.setHint1(savedHint);
+            }
+        } else {
+            if (input.getHint1() != null) {
+                input.getHint1().setId(challenge.getHint1().getId());
+                this.getHintRepository().save(input.getHint1());
+            } else {
+				deletedHint1Id = challenge.getHint1().getId();
+				challenge.setHint1(null);
+            }
+        }
+		Long deletedHint2Id = null;
+		if (challenge.getHint2() == null) {
+			if (input.getHint2() != null) {
+				Hint savedHint = this.getHintRepository().save(input.getHint2());
+				input.setHint2(savedHint);
+			}
+		} else {
+			if (input.getHint2() != null) {
+				input.getHint2().setId(challenge.getHint2().getId());
+				this.getHintRepository().save(input.getHint2());
+			} else {
+				deletedHint2Id = challenge.getHint2().getId();
+				challenge.setHint2(null);
+			}
+		}
 		this.getChallengeRepository().save(input);
+		//TODO catch "constraint violation"
+        if(deletedHint1Id != null ){
+			this.getHintRepository().delete(deletedHint1Id);
+		}
+		if(deletedHint2Id != null ){
+			this.getHintRepository().delete(deletedHint2Id);
+		}
 		return new ResponseEntity<>(null, null, HttpStatus.NO_CONTENT);
 	}
 

--- a/Backend/src/main/java/ar/edu/unlp/dsa/controller/ChallengeRestController.java
+++ b/Backend/src/main/java/ar/edu/unlp/dsa/controller/ChallengeRestController.java
@@ -78,32 +78,36 @@ public class ChallengeRestController {
 		input.setId(challengeId);
 		Long deletedHint1Id = null;
         if (challenge.getHint1() == null) {
-            if (input.getHint1() != null) {
+            if (input.getHint1() != null && input.getHint1().getDescription()!= null && input.getHint1().getPointsPercentageCost()!=null) {
                 Hint savedHint = this.getHintRepository().save(input.getHint1());
                 input.setHint1(savedHint);
-            }
+            } else {
+				input.setHint1(null);
+			}
         } else {
-            if (input.getHint1() != null) {
+            if (input.getHint1() != null && input.getHint1().getDescription()!= null && input.getHint1().getPointsPercentageCost()!=null) {
                 input.getHint1().setId(challenge.getHint1().getId());
                 this.getHintRepository().save(input.getHint1());
             } else {
 				deletedHint1Id = challenge.getHint1().getId();
-				challenge.setHint1(null);
+				input.setHint1(null);
             }
         }
 		Long deletedHint2Id = null;
 		if (challenge.getHint2() == null) {
-			if (input.getHint2() != null) {
+			if (input.getHint2() != null && input.getHint2().getDescription()!= null && input.getHint2().getPointsPercentageCost()!=null) {
 				Hint savedHint = this.getHintRepository().save(input.getHint2());
 				input.setHint2(savedHint);
+			} else {
+				input.setHint2(null);
 			}
 		} else {
-			if (input.getHint2() != null) {
+			if (input.getHint2() != null && input.getHint2().getDescription()!= null && input.getHint2().getPointsPercentageCost()!=null) {
 				input.getHint2().setId(challenge.getHint2().getId());
 				this.getHintRepository().save(input.getHint2());
 			} else {
 				deletedHint2Id = challenge.getHint2().getId();
-				challenge.setHint2(null);
+				input.setHint2(null);
 			}
 		}
 		this.getChallengeRepository().save(input);
@@ -123,13 +127,21 @@ public class ChallengeRestController {
 		// Todo file upload
 		validateCategory(input.getCategory());
 		validateChallenge(input.getNextChallenge());
-		if(input.getHint1() != null ){
-			Hint savedHint = this.getHintRepository().save(input.getHint1());
-			input.setHint1(savedHint);
+		if(input.getHint1() != null) {
+			if (input.getHint1().getDescription() != null && input.getHint1().getPointsPercentageCost() != null) {
+				input.setHint1(null);
+			} else {
+				Hint savedHint = this.getHintRepository().save(input.getHint1());
+				input.setHint1(savedHint);
+			}
 		}
 		if(input.getHint2() != null ){
-			Hint savedHint = this.getHintRepository().save(input.getHint2());
-			input.setHint2(savedHint);
+			if (input.getHint2().getDescription() != null && input.getHint2().getPointsPercentageCost() != null) {
+				input.setHint2(null);
+			} else {
+				Hint savedHint = this.getHintRepository().save(input.getHint2());
+				input.setHint2(savedHint);
+			}
 		}
 		Challenge result = this.getChallengeRepository().save(input);
 		HttpHeaders httpHeaders = new HttpHeaders();

--- a/Backend/src/main/java/ar/edu/unlp/dsa/controller/ChallengeRestController.java
+++ b/Backend/src/main/java/ar/edu/unlp/dsa/controller/ChallengeRestController.java
@@ -83,13 +83,17 @@ public class ChallengeRestController {
 	@CrossOrigin(origins = "http://localhost:"+Application.FRONTEND_PORT)
 	@RequestMapping(method = RequestMethod.POST)
 	ResponseEntity<?> add(@RequestBody Challenge input) {
-		// TODO: Add Category - done
-		// Todo maybe should persist hints separately? - should
 		// Todo file upload
 		validateCategory(input.getCategory());
-		validateHint(input.getHint1());
-		validateHint(input.getHint2());
 		validateChallenge(input.getNextChallenge());
+		if(input.getHint1() != null ){
+			Hint savedHint = this.getHintRepository().save(input.getHint1());
+			input.setHint1(savedHint);
+		}
+		if(input.getHint2() != null ){
+			Hint savedHint = this.getHintRepository().save(input.getHint2());
+			input.setHint2(savedHint);
+		}
 		Challenge result = this.getChallengeRepository().save(input);
 		HttpHeaders httpHeaders = new HttpHeaders();
 		httpHeaders.setLocation(

--- a/Backend/src/main/java/ar/edu/unlp/dsa/model/Challenge.java
+++ b/Backend/src/main/java/ar/edu/unlp/dsa/model/Challenge.java
@@ -20,10 +20,10 @@ public class Challenge {
 
     private String description;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE)
     private Hint hint1;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE)
     private Hint hint2;
 
     private String attachedFileUrl;


### PR DESCRIPTION
Now you can upload a new challenge with its hints embedded.
On a challenge update, hints are created, updated or deleted.
Challenge endpoints also support this:
```json
"hint1" : {}
```
(it's processed as null, i.e. on create it will be ignored and on update it will delete the previous hint)